### PR TITLE
back to ###Quick skim

### DIFF
--- a/content/blog/2017-07-11-skimr.md
+++ b/content/blog/2017-07-11-skimr.md
@@ -97,7 +97,10 @@ Some features of output in the console:
 
 Here are examples of `skimr` in action:
 
-#### Quick skim in the console:
+<br>
+
+### Quick skim in the console:
+
 
 **Nicely separates numeric and factor variables:**
 


### PR DESCRIPTION
can't seem to get heading "####Quick skim ..." onto new line even after adding <br> so reverted it back to "###Quick skim..."
This means this heading still one size too big