### PR TITLE
add break for blog summaries

### DIFF
--- a/content/blog/2016-11-09-ropensci-at-meetings.md
+++ b/content/blog/2016-11-09-ropensci-at-meetings.md
@@ -15,6 +15,8 @@ tags:
 
 You can find members of the rOpenSci team at various meetings and workshops around the world. Come say 'hi', learn about how our [packages](https://ropensci.org/packages/) can enable your research, or about our [onboarding](https://github.com/ropensci/onboarding) process for contributing new packages, discuss software [sustainability](https://ropensci.org/blog/blog/2016/05/25/software-sustanability-ropensci) or tell us how we can help you do open and reproducible research.
 
+<!--more-->
+
 ### Where's rOpenSci?  November 2016 to February 2017
 
 
@@ -23,7 +25,7 @@ You can find members of the rOpenSci team at various meetings and workshops arou
 <thead>
 <tr>
 	<th style="text-align:left;">When</th>
-	<th style="text-align:left;"><a href="https://ropensci.org/about/#leadership">Who</a></th>
+	<th style="text-align:left;"><a href="https://ropensci.org/about/#team">Who</a></th>
 	<th style="text-align:left;">Where</th>
 	<th style="text-align:left;">What</th>
 </tr>

--- a/content/blog/2017-05-01-ropensci-at-meetings.md
+++ b/content/blog/2017-05-01-ropensci-at-meetings.md
@@ -16,6 +16,8 @@ tags:
 
 You can find members of the rOpenSci team at various meetings and workshops around the world. Come say 'hi', learn about how our [packages](https://ropensci.org/packages/) can enable your research, or about our [onboarding](https://github.com/ropensci/onboarding) process for contributing new packages, discuss software [sustainability](https://ropensci.org/blog/blog/2016/05/25/software-sustanability-ropensci) or tell us how we can help you do open and reproducible research.
 
+<!--more-->
+
 ### Where's rOpenSci?
 
 
@@ -23,7 +25,7 @@ You can find members of the rOpenSci team at various meetings and workshops arou
 <thead>
 <tr>
 	<th style="text-align:left;">When</th>
-	<th style="text-align:left;"><a href="https://ropensci.org/about/#leadership">Who</a></th>
+	<th style="text-align:left;"><a href="https://ropensci.org/about/#team">Who</a></th>
 	<th style="text-align:left;">Where</th>
 	<th style="text-align:left;">What</th>
 </tr>

--- a/content/blog/2017-08-11-ropensci-at-meetings.md
+++ b/content/blog/2017-08-11-ropensci-at-meetings.md
@@ -24,7 +24,7 @@ You can find members of the rOpenSci team at various meetings and workshops arou
 <thead>
 <tr>
 	<th style="text-align:left;">When</th>
-	<th style="text-align:left;"><a href="https://ropensci.org/about/#leadership">Who</a></th>
+	<th style="text-align:left;"><a href="https://ropensci.org/about/#team">Who</a></th>
 	<th style="text-align:left;">Where</th>
 	<th style="text-align:left;">What</th>
 </tr>


### PR DESCRIPTION
1. add <!--more--> for better blog summary for ropensci-at-meetings posts
2. in 3 ropensci-at-meetings posts replaced https://ropensci.org/about/#leadership with https://ropensci.org/about/#team