### PR TITLE
replace about/#leadership & #advisors with #team

### DIFF
--- a/content/blog/2016-10-12-your-community-manager.md
+++ b/content/blog/2016-10-12-your-community-manager.md
@@ -39,7 +39,7 @@ Soon, in this blog, I’ll introduce you to our first rOpenSci Fellowship recipi
 
 In the short term, I’ll be doing a lot of lurking, connecting, listening to and chatting with many of you to gain an appreciation of what you need to be successful in doing open and reproducible research and working with the core team to address those needs. I’ll be learning how the community talks about rOpenSci and thus, how to represent rOpenSci in all its richness.
 
-Big thanks go to the [Helmsley Foundation](https://ropensci.org/blog/blog/2015/11/19/hemlsley-trust-funding) for funding this position and to [Jenny Bryan](https://ropensci.org/about/#leadership) for enticing me by saying that the rOpenSci community has her “A+++ five-star rating”.
+Big thanks go to the [Helmsley Foundation](https://ropensci.org/blog/blog/2015/11/19/hemlsley-trust-funding) for funding this position and to [Jenny Bryan](https://ropensci.org/about/#team) for enticing me by saying that the rOpenSci community has her “A+++ five-star rating”.
 
 Talk to Me
 ------

--- a/content/blog/2017-04-27-ropensci-interns.md
+++ b/content/blog/2017-04-27-ropensci-interns.md
@@ -12,7 +12,7 @@ tags:
 - ropensci
 ---
 
-There's a lot of work that goes in to making software: the code that does the thing itself, unit testing, examples, tutorials, documentation, and support. rOpenSci software is created and maintained both by our [staff](https://ropensci.org/about/#staff) and by our (awesome) community. In keeping with our aim to build capacity of software users and developers, three interns from our academic home at [UC Berkeley](https://bids.berkeley.edu/research) are now working with us as well. Our interns are mentored by [Carl Boettiger](https://ropensci.org/about/#leadership), [Scott Chamberlain](https://ropensci.org/about/#leadership), and [Karthik Ram](https://ropensci.org/about/#leadership) and they will receive academic credit and/or pay for their work.
+There's a lot of work that goes in to making software: the code that does the thing itself, unit testing, examples, tutorials, documentation, and support. rOpenSci software is created and maintained both by our [staff](https://ropensci.org/about/#staff) and by our (awesome) community. In keeping with our aim to build capacity of software users and developers, three interns from our academic home at [UC Berkeley](https://bids.berkeley.edu/research) are now working with us as well. Our interns are mentored by [Carl Boettiger](https://ropensci.org/about/#team), [Scott Chamberlain](https://ropensci.org/about/#team), and [Karthik Ram](https://ropensci.org/about/#team) and they will receive academic credit and/or pay for their work.
 
 ## The interns
 

--- a/content/blog/2017-06-30-postdoc-dan-sholler.md
+++ b/content/blog/2017-06-30-postdoc-dan-sholler.md
@@ -16,7 +16,7 @@ tags:
 
 We are pleased to welcome our Postdoctoral Fellow, [Dr. Dan Sholler](https://danielsholler.wordpress.com/). Dan is an expert in qualitative research (yes, you read that correctly) and studies digital infrastructure creation, growth, and maintenance efforts. Through this research interest, he was drawn to the open science community and its ongoing development of tools and communities to support sustainable, reproducible, high-quality research. With rOpenSci, he intends to investigate _what drives scientists to engage with or resist open science tools and communities_.
 
-Dan will be the first postdoc for the rOpenSci project, based at UC Berkeley and the [Berkeley Institute for Data Science](https://bids.berkeley.edu/), supervised by Karthik Ram and co-supervised by [Carl Boettiger](https://ropensci.org/about/#leadership) and [Daniel Katz](http://danielskatz.org/).
+Dan will be the first postdoc for the rOpenSci project, based at UC Berkeley and the [Berkeley Institute for Data Science](https://bids.berkeley.edu/), supervised by Karthik Ram and co-supervised by [Carl Boettiger](https://ropensci.org/about/#team) and [Daniel Katz](http://danielskatz.org/).
 
 <img src="http://i.imgur.com/piOAomv.jpg" alt="Dr Dan Sholler" align="left" style="margin: 0px 20px" width="250" style="float: left;clear:both">
 

--- a/content/blog/2017-07-05-webrockets.md
+++ b/content/blog/2017-07-05-webrockets.md
@@ -40,7 +40,7 @@ Alicia Answers Miles' Questions
 ### Q1: What motivated you to apply for \#runconf17 and then to work on `webrockets`?
 
 I first learned about rOpenSci last summer, while doing an internship at
-Genentech. [Jenny Bryan](https://ropensci.org/about/#leadership) came to
+Genentech. [Jenny Bryan](https://ropensci.org/about/#team) came to
 give a seminar and also participated in a "women in computing" group
 discussion during her visit. During that discussion, she talked about
 how she thought organizations like rOpenSci that are [welcoming and
@@ -137,7 +137,7 @@ Wow. That's hard. I mean there's the little known but dedicated scene
 inhabited by the R Karaoke People group, the fact that there exists
 someone who takes more unadulterated joy in streaming sensor data than
 me (hey Bob!), the hypnotic power of sing song southern accents,
-[Karthik](https://ropensci.org/about/#leadership)'s magic Dolittle-level
+[Karthik](https://ropensci.org/about/#team)'s magic Dolittle-level
 powers over dogs...
 
 But my absolute favorite thing learned would be aspects of all these

--- a/content/blog/2017-07-06-ropensci-fellowships.md
+++ b/content/blog/2017-07-06-ropensci-fellowships.md
@@ -36,7 +36,7 @@ Our first fellowship was awarded to [Dr. Nick Golding](https://ropensci.org/blog
 
 ## Fellowship selection committee
 
-* [**Karthik Ram**](https://ropensci.org/about/#leadership), Committee Chair
+* [**Karthik Ram**](https://ropensci.org/about/#team), Committee Chair
 Karthik is a co-founder of rOpenSci and the project lead. Karthik is also a fellow at the Berkeley Institute for Data Science and the Berkeley Initiative in Global Change Biology at UC Berkeley. Prior to joining Berkeley, he earned his PhD in ecology & evolution from the University of California, Davis. Karthik's interests are focused on reproducible research, especially as it applies to global change. Much of his recent work focuses on building tools and services around open data and growing diverse data science communities.
 
 * [**Mine Cetinkaya-Rundel**](http://www2.stat.duke.edu/~mc301/), Duke University


### PR DESCRIPTION
replace about/#leadership & about/#advisors with about/#team in blog, ~6 files
did not touch this in footers found in content/usecases/...