### PR TITLE
Switch to FiraCode for syntax font

### DIFF
--- a/themes/ropensci/static/css/code.pcss
+++ b/themes/ropensci/static/css/code.pcss
@@ -1,8 +1,8 @@
 /*  Code stuff */
-@import url('https://fonts.googleapis.com/css?family=Space+Mono:400,400i,700,700i');
+@import url(https://unpkg.com/firacode/distr/fira_code.css);
 
 code, pre {
-    font-family: "Space Mono";
+    font-family: "Fira Code";
     font-size: .8rem;
 }
 

--- a/themes/ropensci/static/css/style-new.css
+++ b/themes/ropensci/static/css/style-new.css
@@ -1,5 +1,5 @@
 
-@import url('https://fonts.googleapis.com/css?family=Space+Mono:400,400i,700,700i');/* Reset *//* http://meyerweb.com/eric/tools/css/reset/ 
+@import url(https://unpkg.com/firacode/distr/fira_code.css);/* Reset *//* http://meyerweb.com/eric/tools/css/reset/ 
    v2.0 | 20110126
    License: none (public domain)
 */html, body, div, span, applet, object, iframe,
@@ -1183,7 +1183,7 @@ q:before, q:after {
   border-radius: 20px;
   font-weight: 700;
 }/*  Code stuff */code, pre {
-    font-family: "Space Mono";
+    font-family: "Fira Code";
     font-size: .8rem;
 }code {
     background: #f3f7ff;


### PR DESCRIPTION
Related to https://github.com/ropensci/roweb2/issues/246 I don't really like our current code font. It looks fancy but I find it difficult to read. For example compare some code with the [current font](https://ropensci.org/technotes/2018/07/23/gifski-release/):


<img width="504" alt="old" src="https://user-images.githubusercontent.com/216319/44007034-8ef48a3a-9e8e-11e8-873f-dd66da40512f.png">

Here the ligature joining of the `fi` inside the word `file` make it difficult to read. This is a known problem and there is a PR with a fix on the "open source" Google repo but it has been completely ignored by Google for over 2 years now: https://github.com/googlefonts/spacemono/pull/2



What about using [FiraCode](https://github.com/tonsky/FiraCode)? It is 100% open source and has ligatures including for `<-`, but is a bit more readable. 


This is what it looks like in [FiraCode](https://deploy-preview-251--ropensci.netlify.com/technotes/2018/07/23/gifski-release/). Besides being better designed, [FiraCode](https://github.com/tonsky/FiraCode) itself is maintained by a nice person who responds to issues and pull requests.

<img width="499" alt="new" src="https://user-images.githubusercontent.com/216319/44007036-949ed288-9e8e-11e8-8200-c9ad15ae0974.png">

