### PR TITLE
Alternative link to ropensci labs

### DIFF
--- a/themes/ropensci/layouts/partials/footer.html
+++ b/themes/ropensci/layouts/partials/footer.html
@@ -8,8 +8,9 @@
 
                 <div class="col-9 col-offset-2 top-10 bottom-8">
                     <div class="row between">
-                        <div class="col-2 col-1-3">
+                        <div class="col-3 col-1-3">
                             <a href="http://github.com/ropensci" target="_blank"><div class="icon icon-github"></div></a>
+                            <a href="http://github.com/ropenscilabs" target="_blank"><div class="icon fa fa-icon fa-flask"></div></a>
                             <a href="http://twitter.com/ropensci" target="_blank"><div class="icon icon-twitter"></div></a>
                             <a href="http://vimeo.com/ropensci" target="_blank"><div class="icon icon-vimeo"></div></a>
                         </div>

--- a/themes/ropensci/static/css/sections.pcss
+++ b/themes/ropensci/static/css/sections.pcss
@@ -460,7 +460,7 @@ article {
         border-top: 1px solid #5595e8;
     }
     & .icon {
-        width: 30.6%;
+        width: 20%;
         font-size: 1rem;
         display: inline-block;
     }

--- a/themes/ropensci/static/css/style-new.css
+++ b/themes/ropensci/static/css/style-new.css
@@ -598,6 +598,11 @@ q:before, q:after {
   line-height: 0rem;
   float: left;
   margin-top: 9px;
+}.fa-icon:before {
+  font-size: 1.2rem;
+  line-height: 0rem;
+  float: left;
+  margin-top: 9px;
 }.icon-search:before {
   content: "\70";
 }.icon-ropensci-short:before {
@@ -949,7 +954,7 @@ q:before, q:after {
 }#footer .divider{
   border-top: 1px solid #5595e8;
 }#footer .icon{
-  width: 30.6%;
+  width: 20%;
   font-size: 1rem;
   display: inline-block;
 }#footer h5{

--- a/themes/ropensci/static/css/typesetting.pcss
+++ b/themes/ropensci/static/css/typesetting.pcss
@@ -364,6 +364,12 @@ i.ropensci-icons {
   float: left;
   margin-top: 9px;
 }
+.fa-icon:before {
+  font-size: 1.2rem;
+  line-height: 0rem;
+  float: left;
+  margin-top: 9px;
+}
 .icon-search:before {
   content: "\70";
 }


### PR DESCRIPTION
An alternative to: https://github.com/ropensci/roweb2/pull/371

Add ropenscilabs link as an icon.