### PR TITLE
Tech note about rodev

### DIFF
--- a/content/technotes/2019-05-21-rodev.md
+++ b/content/technotes/2019-05-21-rodev.md
@@ -41,7 +41,7 @@ To foster collaboration-friendliness of repos, we have templates for issues, PRs
 
 ### DESCRIPTION tweaking
 
-We've been thinking about asking authors of peer-reviewed packages to add a mention of rOpenSci in the description of their package DESCRIPTION (this sentence is case-sensitive!). We haven't added this to our guidance yet, but if/when we do, `rodev::add_ro_desc()` will add the sentence "This package has been peer-reviewed by rOpenSci (v. `{version}`)." to the description, with `version` automatically replaced by the package current version.
+We've been thinking about asking authors of peer-reviewed packages to add a mention of rOpenSci in the Description of their package DESCRIPTION (this sentence is case-sensitive!). We haven't added this to our guidance yet, but if/when we do, `rodev::add_ro_desc()` will add the sentence "This package has been peer-reviewed by rOpenSci (v. `{version}`)." to the Description, with `version` automatically replaced by the package current version.
 
 For rOpenSci staff members, rOpenSci is a _funder_ of their work so they can run `rodev::add_ro_fnd()` to add rOpenSci as an author in DESCRIPTION.
 

--- a/content/technotes/2019-05-21-rodev.md
+++ b/content/technotes/2019-05-21-rodev.md
@@ -1,6 +1,6 @@
 ---
 slug: rodev
-title: 'rodev: helpers for rOpenSci package maintainers'
+title: 'rodev: helpers for rOpenSci package authors'
 date: '2019-05-21'
 topicid: 
 authors:
@@ -11,13 +11,13 @@ tags:
   - Software Peer Review
 ---
 
-We strive for high quality in [our suite of packages](/packages/), in practice via a [system of software peer review](/software-review/), and via [packaging guidelines that keep growing](https://ropensci.github.io/dev_guide/). There is therefore a risk of increasing the work load of package authors, who already have a lot on their plate. To avoid that, we try to not only document how to do things in our dev guide; we also try to have automated tools at hand to recommend to authors. 
+We strive for high quality in [our suite of packages](/packages/), in practice via a [system of software peer review](/software-review/), and via [packaging guidelines that keep growing](https://ropensci.github.io/dev_guide/). There is therefore a risk of increasing the workload of package authors, who already have a lot on their plate. To avoid that, we try to not only document how to do things in our dev guide; we also try to have automated tools at hand to recommend to authors. 
 
 {{< tweet 935562495816753153 >}}
 
-Inspired by [`usethis`](https://usethis.r-lib.org/), we've started work on our specific helpers for rOpenSci package authors, [`rodev`](https://ropenscilabs.github.io/rodev/). In this note, we'll present the helpers it contains at the moment, and ask for the feedback of you as an rOpenSci package author.
+Inspired by [`usethis`](https://usethis.r-lib.org/), we've started work on our specific helpers for rOpenSci package authors, [`rodev`](https://docs.ropensci.org/rodev/). In this note, we'll present the helpers it contains at the moment, and ask for the feedback of you as an rOpenSci package author.
 
-### Setup
+### Setup and scope
 
 To use `rodev`, you'll need to install it from GitHub,
 
@@ -26,3 +26,27 @@ remotes::install_github("ropenscilabs/rodev")
 ```
 
 and then, go to the package project you want to test it on. Indeed, `rodev` works on the active project [as defined by `usethis`](https://usethis.r-lib.org/#usage).
+
+At the moment, [`rodev` functions](https://docs.ropensci.org/rodev/reference/index.html) are divided into four categories in the pkgdown website reference. In this post, we'll take a different approach, but hope you'll refer to the online reference too!
+
+### Helper for badges
+
+We recommend, and therefore `rodev` facilitates, the use of [repostatus.org badges](https://www.repostatus.org/) via [`use_repostatus_badge()`](https://docs.ropensci.org/rodev/reference/use_repostatus_badge.html), that calls [`usethis::use_badge()`](https://usethis.r-lib.org/reference/badges.html). At a minimum `rodev::use_repostatus_badge("wip")` will paste the Markdown code of the badge to your clipboard, but as a reminder from `usethis` docs "To add badges automatically ensure your badge block starts with a line containing only `<!-- badges: start -->` and ends with a line containing only `<!-- badges: end -->`." To see what statuses are available, you can call `rodev::repostatus_badges()` that'll output a `data.frame`.
+
+Another badge we help authors adding, if their software is under / underwent review, is a peer-review badge, via `rodev::use_review_badge()` that takes the software review issue number as an argument. E.g. the peer-review badge of the [`tradestatistics` package](https://docs.ropensci.org/tradestatistics/) uses the number 274 because it was reviewed in [issue 274](https://github.com/ropensci/onboarding/issues/274).
+
+### One-liner for collaboration friendliness
+
+To foster collaboration-friendliness of repos, we have templates for issues, PRs and CONTRIBUTING.md. Such files need to live in a .github/ folder. Package authors can get our templates by running `rodev::use_ro_github()` and voilà! the package has a .github/ folder ready to be committed and pushed.
+
+### DESCRIPTION tweaking
+
+We've been thinking about asking authors of peer-reviewed packages to add a mention of rOpenSci in the description of their package DESCRIPTION (this sentence is case-sensitive!). We haven't added this to our guidance yet, but if/when we do, `rodev::add_ro_desc()` will add the sentence "This package has been peer-reviewed by rOpenSci (v. `{version}`)." to the description, with version automatically replaced by the package current version.
+
+For rOpenSci staff members, rOpenSci is a _funder_ of their work so they can run `rodev::add_ro_fnd()` to add rOpenSci as an author in DESCRIPTION.
+
+### Conclusion
+
+In this note we briefly presented `rodev`, a package of helpers for rOpenSci package authors. Its contents, and the behavior of some functions, are expected to change when our guidelines do. We've just added a changelog to the package -- via `usethis::use_news_md()`, so at least evolutions will be tracked!
+
+Do some of [`rodev` helpers](https://docs.ropensci.org/rodev/reference/index.html) sound helpful? Do they work as expected? Do you have some feature requests? Head to [`rodev` issue tracker](https://github.com/ropenscilabs/rodev/issues), we'd be glad to improve the package.

--- a/content/technotes/2019-05-21-rodev.md
+++ b/content/technotes/2019-05-21-rodev.md
@@ -15,23 +15,23 @@ We strive for high quality in [our suite of packages](/packages/), in practice v
 
 {{< tweet 935562495816753153 >}}
 
-Inspired by [`usethis`](https://usethis.r-lib.org/), we've started work on our specific helpers for rOpenSci package authors, [`rodev`](https://docs.ropensci.org/rodev/). In this note, we'll present some of the helpers it contains at the moment, and ask for your feedback as an rOpenSci package author.
+Inspired by [the usethis package](https://usethis.r-lib.org/), we've started work on our specific helpers for rOpenSci package authors, [rodev](https://docs.ropensci.org/rodev/). In this note, we'll present some of the helpers it contains at the moment, and ask for your feedback as an rOpenSci package author.
 
 ### Setup and scope
 
-To use `rodev`, you'll need to install it from GitHub,
+To use rodev, you'll need to install it from GitHub,
 
 ```r
 remotes::install_github("ropenscilabs/rodev")
 ```
 
-and then, go to the package project you want to test it on. Indeed, `rodev` works on the active project [as defined by `usethis`](https://usethis.r-lib.org/#usage).
+and then, go to the package project you want to test it on. Indeed, rodev works on the active project [as defined by usethis](https://usethis.r-lib.org/#usage).
 
-At the moment, [`rodev` functions are divided into four categories in the pkgdown website reference](https://docs.ropensci.org/rodev/reference/index.html). In this post, we will not reproduce this classification, but hope you'll refer to the online reference too!
+At the moment, [rodev functions are divided into four categories in the pkgdown website reference](https://docs.ropensci.org/rodev/reference/index.html). In this post, we will not reproduce this classification, but hope you'll refer to the online reference too!
 
 ### Helper for badges
 
-We recommend, and therefore `rodev` facilitates, the use of [repostatus.org badges](https://www.repostatus.org/) via [`use_repostatus_badge()`](https://docs.ropensci.org/rodev/reference/use_repostatus_badge.html), that calls [`usethis::use_badge()`](https://usethis.r-lib.org/reference/badges.html). At a minimum `rodev::use_repostatus_badge("wip")` will paste the Markdown code of the badge to your clipboard, but as a reminder from `usethis` docs "To add badges automatically ensure your badge block starts with a line containing only `<!-- badges: start -->` and ends with a line containing only `<!-- badges: end -->`." To see what statuses are available, you can call `rodev::repostatus_badges()` that'll output a `data.frame`.
+We recommend, and therefore rodev facilitates, the use of [repostatus.org badges](https://www.repostatus.org/) via [`use_repostatus_badge()`](https://docs.ropensci.org/rodev/reference/use_repostatus_badge.html), that calls [`usethis::use_badge()`](https://usethis.r-lib.org/reference/badges.html). At a minimum `rodev::use_repostatus_badge("wip")` will paste the Markdown code of the badge to your clipboard, but as a reminder from `usethis` docs "To add badges automatically ensure your badge block starts with a line containing only `<!-- badges: start -->` and ends with a line containing only `<!-- badges: end -->`." To see what statuses are available, you can call `rodev::repostatus_badges()` that'll output a `data.frame`.
 
 Another badge we help authors adding, if their software is under / underwent review, is a peer-review badge, via `rodev::use_review_badge()` that takes the software review issue number as an argument. E.g. the peer-review badge of the [`tradestatistics` package](https://docs.ropensci.org/tradestatistics/) uses the number 274 because it was reviewed in [issue 274](https://github.com/ropensci/onboarding/issues/274).
 
@@ -47,6 +47,6 @@ For rOpenSci staff members, rOpenSci is a _funder_ of their work so they can run
 
 ### Conclusion
 
-In this note we briefly presented `rodev`, a package of helpers for rOpenSci package authors. Its contents, and the behavior of some functions, are expected to change when our guidelines do. Our goal is to add `rodev` functions in our dev guide. Speaking of our guidance, `rodev::read_pkg_guide()` will open our online packaging guide in a browser! Also note that we've just added a changelog to the package -- via `usethis::use_news_md()`, so evolutions will be tracked!
+In this note we briefly presented rodev, a package of helpers for rOpenSci package authors. Its contents, and the behavior of some functions, are expected to change when our guidelines do. Our goal is to add rodev functions in our dev guide. Speaking of our guidance, `rodev::read_pkg_guide()` will open our online packaging guide in a browser! Also note that we've just added a changelog to the package -- via `usethis::use_news_md()`, so evolutions will be tracked!
 
-Do some of [`rodev` helpers](https://docs.ropensci.org/rodev/reference/index.html) sound helpful? Do they work as expected? Do you have some feature requests? Head to [`rodev` issue tracker](https://github.com/ropenscilabs/rodev/issues), we'd be glad to improve the package and ultimately your experience as the author of an rOpenSci package.
+Do some of [rodev helpers](https://docs.ropensci.org/rodev/reference/index.html) sound helpful? Do they work as expected? Do you have some feature requests? Head to [rodev issue tracker](https://github.com/ropenscilabs/rodev/issues), we'd be glad to improve the package and ultimately your experience as the author of an rOpenSci package.

--- a/content/technotes/2019-05-21-rodev.md
+++ b/content/technotes/2019-05-21-rodev.md
@@ -1,0 +1,28 @@
+---
+slug: rodev
+title: 'rodev: helpers for rOpenSci package maintainers'
+date: '2019-05-21'
+topicid: 
+authors:
+  - Maëlle Salmon
+categories: technotes
+tags:
+  - rodev
+  - Software Peer Review
+---
+
+We strive for high quality in [our suite of packages](/packages/), in practice via a [system of software peer review](/software-review/), and via [packaging guidelines that keep growing](https://ropensci.github.io/dev_guide/). There is therefore a risk of increasing the work load of package authors, who already have a lot on their plate. To avoid that, we try to not only document how to do things in our dev guide; we also try to have automated tools at hand to recommend to authors. 
+
+{{< tweet 935562495816753153 >}}
+
+Inspired by [`usethis`](https://usethis.r-lib.org/), we've started work on our specific helpers for rOpenSci package authors, [`rodev`](https://ropenscilabs.github.io/rodev/). In this note, we'll present the helpers it contains at the moment, and ask for the feedback of you as an rOpenSci package author.
+
+### Setup
+
+To use `rodev`, you'll need to install it from GitHub,
+
+```r
+remotes::install_github("ropenscilabs/rodev")
+```
+
+and then, go to the package project you want to test it on. Indeed, `rodev` works on the active project [as defined by `usethis`](https://usethis.r-lib.org/#usage).

--- a/content/technotes/2019-05-21-rodev.md
+++ b/content/technotes/2019-05-21-rodev.md
@@ -27,7 +27,7 @@ remotes::install_github("ropenscilabs/rodev")
 
 and then, go to the package project you want to test it on. Indeed, `rodev` works on the active project [as defined by `usethis`](https://usethis.r-lib.org/#usage).
 
-At the moment, [`rodev` functions are divided into four categories in the pkgdown website reference](https://docs.ropensci.org/rodev/reference/index.html). In this post, we'll take a different approach, but hope you'll refer to the online reference too!
+At the moment, [`rodev` functions are divided into four categories in the pkgdown website reference](https://docs.ropensci.org/rodev/reference/index.html). In this post, we will not reproduce this classification, but hope you'll refer to the online reference too!
 
 ### Helper for badges
 

--- a/content/technotes/2019-05-21-rodev.md
+++ b/content/technotes/2019-05-21-rodev.md
@@ -15,7 +15,7 @@ We strive for high quality in [our suite of packages](/packages/), in practice v
 
 {{< tweet 935562495816753153 >}}
 
-Inspired by [`usethis`](https://usethis.r-lib.org/), we've started work on our specific helpers for rOpenSci package authors, [`rodev`](https://docs.ropensci.org/rodev/). In this note, we'll present the helpers it contains at the moment, and ask for the feedback of you as an rOpenSci package author.
+Inspired by [`usethis`](https://usethis.r-lib.org/), we've started work on our specific helpers for rOpenSci package authors, [`rodev`](https://docs.ropensci.org/rodev/). In this note, we'll present some of the helpers it contains at the moment, and ask for your feedback as an rOpenSci package author.
 
 ### Setup and scope
 
@@ -27,7 +27,7 @@ remotes::install_github("ropenscilabs/rodev")
 
 and then, go to the package project you want to test it on. Indeed, `rodev` works on the active project [as defined by `usethis`](https://usethis.r-lib.org/#usage).
 
-At the moment, [`rodev` functions](https://docs.ropensci.org/rodev/reference/index.html) are divided into four categories in the pkgdown website reference. In this post, we'll take a different approach, but hope you'll refer to the online reference too!
+At the moment, [`rodev` functions are divided into four categories in the pkgdown website reference](https://docs.ropensci.org/rodev/reference/index.html). In this post, we'll take a different approach, but hope you'll refer to the online reference too!
 
 ### Helper for badges
 
@@ -41,12 +41,12 @@ To foster collaboration-friendliness of repos, we have templates for issues, PRs
 
 ### DESCRIPTION tweaking
 
-We've been thinking about asking authors of peer-reviewed packages to add a mention of rOpenSci in the description of their package DESCRIPTION (this sentence is case-sensitive!). We haven't added this to our guidance yet, but if/when we do, `rodev::add_ro_desc()` will add the sentence "This package has been peer-reviewed by rOpenSci (v. `{version}`)." to the description, with version automatically replaced by the package current version.
+We've been thinking about asking authors of peer-reviewed packages to add a mention of rOpenSci in the description of their package DESCRIPTION (this sentence is case-sensitive!). We haven't added this to our guidance yet, but if/when we do, `rodev::add_ro_desc()` will add the sentence "This package has been peer-reviewed by rOpenSci (v. `{version}`)." to the description, with `version` automatically replaced by the package current version.
 
 For rOpenSci staff members, rOpenSci is a _funder_ of their work so they can run `rodev::add_ro_fnd()` to add rOpenSci as an author in DESCRIPTION.
 
 ### Conclusion
 
-In this note we briefly presented `rodev`, a package of helpers for rOpenSci package authors. Its contents, and the behavior of some functions, are expected to change when our guidelines do. We've just added a changelog to the package -- via `usethis::use_news_md()`, so at least evolutions will be tracked!
+In this note we briefly presented `rodev`, a package of helpers for rOpenSci package authors. Its contents, and the behavior of some functions, are expected to change when our guidelines do. Our goal is to add `rodev` functions in our dev guide. Speaking of our guidance, `rodev::read_pkg_guide()` will open our online packaging guide in a browser! Also note that we've just added a changelog to the package -- via `usethis::use_news_md()`, so evolutions will be tracked!
 
-Do some of [`rodev` helpers](https://docs.ropensci.org/rodev/reference/index.html) sound helpful? Do they work as expected? Do you have some feature requests? Head to [`rodev` issue tracker](https://github.com/ropenscilabs/rodev/issues), we'd be glad to improve the package.
+Do some of [`rodev` helpers](https://docs.ropensci.org/rodev/reference/index.html) sound helpful? Do they work as expected? Do you have some feature requests? Head to [`rodev` issue tracker](https://github.com/ropenscilabs/rodev/issues), we'd be glad to improve the package and ultimately your experience as the author of an rOpenSci package.

--- a/content/technotes/2019-05-21-rodev.md
+++ b/content/technotes/2019-05-21-rodev.md
@@ -11,7 +11,7 @@ tags:
   - Software Peer Review
 ---
 
-We strive for high quality in [our suite of packages](/packages/), in practice via a [system of software peer review](/software-review/), and via [packaging guidelines that keep growing](https://ropensci.github.io/dev_guide/). There is therefore a risk of increasing the workload of package authors, who already have a lot on their plate. To avoid that, we try to not only document how to do things in our dev guide; we also try to have automated tools at hand to recommend to authors. 
+We strive for high quality in [our suite of packages](/packages/), in practice via a [system of software peer review](/software-review/), and via [packaging guidelines that keep growing](https://ropensci.github.io/dev_guide/). There is therefore a risk of increasing the workload of package authors, who already have a lot on their plate. To avoid that, we try to document how to do things in our dev guide, and we also try to have automated tools at hand to recommend to authors. 
 
 {{< tweet 935562495816753153 >}}
 

--- a/content/technotes/2019-05-21-rodev.md
+++ b/content/technotes/2019-05-21-rodev.md
@@ -11,7 +11,7 @@ tags:
   - Software Peer Review
 ---
 
-We strive for high quality in [our suite of packages](/packages/), in practice via a [system of software peer review](/software-review/), and via [packaging guidelines that keep growing](https://ropensci.github.io/dev_guide/). There is therefore a risk of increasing the workload of package authors, who already have a lot on their plate. To avoid that, we try to document how to do things in our dev guide, and we also try to have automated tools at hand to recommend to authors. 
+We strive for high quality in [our suite of packages](/packages/), in practice via a [system of software peer review](/software-review/), and via [packaging guidelines that keep growing](https://ropensci.github.io/dev_guide/). There is therefore a risk of increasing the workload of package authors, who already have a lot on their plate. To avoid that, when explaining how to do things in our dev guide, we recommend existing automated tools to authors. 
 
 {{< tweet 935562495816753153 >}}
 


### PR DESCRIPTION
Publication date to be set by @stefaniebutland.

The package does very little, and some of the things it does could change soon:

* E.g. there are functions helpìng with rOpenSci branding but with @jeroen's central builds of docs, this will be useless.

* The CI setup function is useful for now, but when `tic` & `travis` are released, it might change.

I've tried to make clear in the tech note that `rodev` would follow evolutions of our packaging guidance.