### PR TITLE
Split team data from team formatting

### DIFF
--- a/data/team/alumni.json
+++ b/data/team/alumni.json
@@ -1,0 +1,9 @@
+[
+{
+   "name": "Dan Sholler",
+   "url": "/authors/dan-sholler",
+   "image" : "/img/team/dan-sholler.jpg",
+   "roles": [
+      "postdoc"
+   ]
+}]

--- a/data/team/fellows.json
+++ b/data/team/fellows.json
@@ -1,0 +1,30 @@
+[{
+   "name": "Kelly Hondula",
+   "url": "https://www.sesync.org/users/khondula",
+   "image" : "/img/team/kelly-hondula.jpg",
+   "affiliation" : "University of Maryland, SESYNC"
+},
+{
+   "name": "Zachary Foster",
+   "url": "https://github.com/zachary-foster",
+   "image" : "/img/team/zachary-foster.jpg",
+   "affiliation" : "Oregon State University"
+},
+{
+   "name": "Sam Tyner",
+   "url": "https://sctyner.github.io/",
+   "image" : "/img/team/sam-tyner.jpg",
+   "affiliation" : "Iowa State University, CSAFE"
+},
+{
+   "name": "Jon Zelner",
+   "url": "http://www.jonzelner.net/",
+   "image" : "/img/team/jon-zelner.jpg",
+   "affiliation" : "University of Michigan"
+},
+{
+   "name": "Nick Golding",
+   "url": "https://github.com/goldingn",
+   "image" : "/img/team/nick-golding.jpg",
+   "affiliation" : "University of Melbourne"
+}]

--- a/data/team/team.json
+++ b/data/team/team.json
@@ -157,4 +157,22 @@
    "roles": [
       "advisor"
    ]
+},
+{
+   "name": "Matt Jones",
+   "url": "http://matt.magisa.org/",
+   "image" : "/img/team/matt_jones.png",
+   "affiliation" : "NCEAS",
+   "roles": [
+      "advisor"
+   ]
+},
+{
+   "name": "Nico Cellinese",
+   "url": "https://www.floridamuseum.ufl.edu/museum-voices/nico-cellinese/",
+   "image" : "/img/team/nico_cellinese.jpg",
+   "affiliation" : "University of Florida",
+   "roles": [
+      "advisor"
+   ]
 }]

--- a/data/team/team.json
+++ b/data/team/team.json
@@ -9,9 +9,9 @@
    ]
 },
 {
-   "name": "Karthik Ram",
-   "url": "/authors/karthik-ram",
-   "image" : "/img/team/member.jpg",
+   "name": "Scott Chamberlain",
+   "url": "/authors/scott-chamberlain",
+   "image" : "/img/team/scott.png",
    "roles": [
       "staff",
       "leadership",
@@ -19,12 +19,61 @@
    ]
 },
 {
-   "name": "Karthik Ram",
-   "url": "/authors/karthik-ram",
-   "image" : "/img/team/member.jpg",
+   "name": "Jeroen Ooms",
+   "url": "/authors/jeroen-ooms",
+   "image" : "/img/team/jeroen_ooms.jpg",
    "roles": [
       "staff",
-      "leadership",
+      "postdoc"
+   ]
+},
+{
+   "name": "Stefanie Butland",
+   "url": "/authors/stefanie-butland",
+   "image" : "/img/team/stefanie_butland.jpg",
+   "roles": [
+      "staff"
+   ]
+},
+{
+   "name": "Maëlle Salmon",
+   "url": "/authors/maëlle-salmon",
+   "image" : "/img/team/maelle_salmon.jpg",
+   "roles": [
+      "staff",
       "editor"
+   ]
+},
+{
+   "name": "Dan Sholler",
+   "url": "/authors/dan-sholler",
+   "image" : "/img/team/dan-sholler.jpg",
+   "roles": [
+      "postdoc"
+   ]
+},
+{
+   "name": "Stacey Dorton",
+   "image" : "/img/team/stacey.png",
+   "roles": [
+      "staff"
+   ]
+},
+{
+   "name": "Carl Boettiger",
+   "url": "https://carlboettiger.info/",
+   "image" : "/img/team/carl.jpg",
+   "affiliation" : "University of California, Berkeley",
+   "roles": [
+      "leadership"
+   ]
+},
+{
+   "name": "Jenny Bryan",
+   "url": "https://jennybryan.org/",
+   "image" : "/img/team/jenny_bryan.jpg",
+   "affiliation" : "RStudio",
+   "roles": [
+      "leadership"
    ]
 }]

--- a/data/team/team.json
+++ b/data/team/team.json
@@ -45,14 +45,6 @@
    ]
 },
 {
-   "name": "Dan Sholler",
-   "url": "/authors/dan-sholler",
-   "image" : "/img/team/dan-sholler.jpg",
-   "roles": [
-      "postdoc"
-   ]
-},
-{
    "name": "Stacey Dorton",
    "image" : "/img/team/stacey.png",
    "roles": [

--- a/data/team/team.json
+++ b/data/team/team.json
@@ -1,0 +1,30 @@
+[{
+   "name": "Karthik Ram",
+   "url": "/authors/karthik-ram",
+   "image" : "/img/team/member.jpg",
+   "roles": [
+      "staff",
+      "leadership",
+      "editor"
+   ]
+},
+{
+   "name": "Karthik Ram",
+   "url": "/authors/karthik-ram",
+   "image" : "/img/team/member.jpg",
+   "roles": [
+      "staff",
+      "leadership",
+      "editor"
+   ]
+},
+{
+   "name": "Karthik Ram",
+   "url": "/authors/karthik-ram",
+   "image" : "/img/team/member.jpg",
+   "roles": [
+      "staff",
+      "leadership",
+      "editor"
+   ]
+}]

--- a/data/team/team.json
+++ b/data/team/team.json
@@ -76,4 +76,85 @@
    "roles": [
       "leadership"
    ]
+},
+{
+   "name": "Rich FitzJohn",
+   "url": "https://richfitz.github.io/",
+   "image" : "/img/team/rich_fitzjohn.jpg",
+   "affiliation" : "Imperial College London",
+   "roles": [
+      "leadership"
+   ]
+},
+{
+   "name": "Noam Ross",
+   "url": "http://www.ecohealthalliance.org/personnel/dr-noam-ross",
+   "image" : "/img/team/noam_ross.png",
+   "affiliation" : "EcoHealth Alliance",
+   "roles": [
+      "editor"
+   ]
+},
+{
+   "name": "Anna Krystalli",
+   "url": "http://annakrystalli.me/",
+   "image" : "/img/team/anna-krystalli.jpg",
+   "affiliation" : "University of Sheffield",
+   "roles": [
+      "editor"
+   ]
+},
+{
+   "name": "Lincoln Mullen",
+   "url": "https://lincolnmullen.com/",
+   "image" : "/img/team/lincoln-mullen.jpg",
+   "affiliation" : "George Mason University",
+   "roles": [
+      "editor"
+   ]
+},
+{
+   "name": "Brooke Anderson",
+   "url": "http://csu-cvmbs.colostate.edu/academics/erhs/Pages/brooke-anderson.aspx",
+   "image" : "/img/team/brooke-anderson.jpg",
+   "affiliation" : "Colorado State University",
+   "roles": [
+      "editor"
+   ]
+},
+{
+   "name": "Melina Vidoni",
+   "url": "https://melvidoni.rbind.io/",
+   "image" : "/img/team/melina-vidoni.jpg",
+   "affiliation" : "RMIT University",
+   "roles": [
+      "editor"
+   ]
+},
+{
+   "name": "Hadley Wickham",
+   "url": "http://hadley.nz/",
+   "image" : "/img/team/hadley-wickham.jpg",
+   "affiliation" : "RStudio",
+   "roles": [
+      "advisor"
+   ]
+},
+{
+   "name": "JJ Allaire",
+   "url": "https://github.com/jjallaire",
+   "image" : "/img/team/jj_allaire.png",
+   "affiliation" : "RStudio",
+   "roles": [
+      "advisor"
+   ]
+},
+{
+   "name": "Mackenzie Smith",
+   "url": "https://www.library.ucdavis.edu/about/university-librarian/",
+   "image" : "/img/team/mackenzie_smith.jpg",
+   "affiliation" : "University of California, Davis",
+   "roles": [
+      "advisor"
+   ]
 }]

--- a/themes/ropensci/layouts/_default/single.html
+++ b/themes/ropensci/layouts/_default/single.html
@@ -29,11 +29,8 @@
 <p> Find all blog posts, tech notes and community calls <a href="/tags/" target="_blank">by tag</a> and <a href="/authors/" target="_blank">by author</a>. </p>
           </div>
       {{else}}
-      {{if (eq $elem_val "community.html")}}
-        {{ partial "community.html" (dict "Site" $.Site) }}
-        {{ else }}
-        {{ partial $elem_val . }}
-        {{ end }}
+        {{ partial $elem_val (dict "Site" $.Site "Data" $.Site.Data) }}
+
         
       {{end}}
   {{ end }}

--- a/themes/ropensci/layouts/partials/about.html
+++ b/themes/ropensci/layouts/partials/about.html
@@ -42,35 +42,7 @@
                     <p>Our 2017 & 2018 research fellows were awarded support for their ongoing work in open science to enable them to have a bigger voice in their communities.</p>
                 </div>
             </div>
-            <div class="row center">
-                <div class="col-2 top-12">
-                    <img src="/img/team/kelly-hondula.jpg" />
-                    <h5><a href="https://www.sesync.org/users/khondula">Kelly Hondula</a></h5>
-                    <h5>University of Maryland, SESYNC</h5>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/zachary-foster.jpg" />
-                    <h5><a href="https://github.com/zachary-foster">Zachary Foster</a></h5>
-                    <h5>Oregon State University</h5>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/sam-tyner.jpg" />
-                    <h5><a href="https://sctyner.github.io/">Sam Tyner</a></h5>
-                    <h5>Iowa State University, CSAFE</h5>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/jon-zelner.jpg" />
-                    <h5><a href="http://www.jonzelner.net/">Jon Zelner</a></h5>
-                    <h5>University of Michigan</h5>
-                </div>
-            </div>
-            <div class="row center">
-                <div class="col-2 top-12">
-                    <img src="/img/team/nick-golding.jpg" />
-                    <h5><a href="https://github.com/goldingn">Nick Golding</a></h5>
-                    <h5>University of Melbourne</h5>
-                </div>
-            </div>
+ {{ partial "team.html" (dict "team" $.Data.team.fellows)  }}           
         </div>
     </section>
     <!-- /team -->

--- a/themes/ropensci/layouts/partials/about.html
+++ b/themes/ropensci/layouts/partials/about.html
@@ -8,28 +8,6 @@
 
     </section>
     <section id="team" class="team">
-      <div class="container">
-        {{ $team := $.Data.team.team }}
-        {{ $lenteam := 1 }}
-{{ $columns := 4 }}
-{{ $rows := div $lenteam $columns }}
-{{ $rows := math.Ceil $rows }}
-
-{{ range (seq 1 $rows) }}
-{{ $y := . }}
-            <div class="row center">
-{{ range (seq 1 $columns) }}
-{{ $i := ( add . $y ) }}
-                <div class="col-2 top-12">
-                  {{ $teammember := (index $team (sub $i 1)) }}
-   {{ partial "team.html" $teammember }}
-   </div>
-   {{ end }}
-</div>
-{{ end }}
-</div>
-</section>
-    <section id="team" class="team">
         <div class="container">
             <div class="row center">
                 <div class="col-10 top-12">
@@ -41,64 +19,26 @@
                     <p>Our core team includes staff and postdoctoral fellows. Our leadership and editorial board members are volunteers.</p>
                 </div>
             </div>
+{{ $team := $.Data.team.team }}
+{{ $lenteam := (len $team) }}
+{{ $columns := 4.0 }}
+{{ $rows := div $lenteam $columns }}
+{{ $rows := math.Ceil $rows }}
+{{ range (seq 1 $rows) }}
+  {{ $y := (add (mul (sub . 1)  4) 1)}}
+  <div class="row center">
+  {{ range (seq 1 $columns) }}
+    {{ $i := ( add . $y ) }}
+    {{ $i := (sub $i 2)}}
+    {{ if (le $i (sub $lenteam 1)) }}
+      {{ $teammember := (index $team $i) }}
+      {{ partial "team.html" $teammember }}
+    {{ end }}
+  {{ end }}
+  </div>
+{{ end }}
+
             <div class="row center">
-                <div class="col-2 top-12">
-                    <img src="/img/team/member.jpg" />
-                    <h5><a href="/authors/karthik-ram">Karthik Ram</a></h5>
-                    <span class="label staff"></span>
-                    <span class="label leadership"></span>
-                    <span class="label editor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/scott.png" />
-                    <h5><a href="/authors/scott-chamberlain">Scott Chamberlain</a></h5>
-                    <span class="label staff"></span>
-                    <span class="label leadership"></span>
-                    <span class="label editor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/jeroen_ooms.jpg" />
-                    <h5><a href="/authors/jeroen-ooms">Jeroen Ooms</a></h5>
-                    <span class="label staff"></span>
-                    <span class="label postdoc"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/stefanie_butland.jpg" />
-                    <h5><a href="/authors/stefanie-butland">Stefanie Butland</a></h5>
-                    <span class="label staff"></span>
-                </div>
-            </div>
-            <div class="row center">
-                <div class="col-2 top-12">
-                    <img src="/img/team/maelle_salmon.jpg" />
-                    <h5><a href="/authors/maëlle-salmon">Maëlle Salmon</a></h5>
-                    <span class="label staff"></span>
-                    <span class="label editor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/dan-sholler.jpg" />
-                    <h5><a href="/authors/dan-sholler">Dan Sholler</a></h5>
-                    <span class="label postdoc"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/stacey.png" />
-                    <h5>Stacey Dorton</h5>
-                    <span class="label staff"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/carl.jpg" />
-                    <h5><a href="https://carlboettiger.info/">Carl Boettiger</a></h5>
-                    <h5>University of California, Berkeley</h5>
-                    <span class="label leadership"></span>
-                </div>
-            </div>
-            <div class="row center">
-                <div class="col-2 top-12">
-                    <img src="/img/team/jenny_bryan.jpg" />
-                    <h5><a href="https://jennybryan.org/">Jenny Bryan</a></h5>
-                    <h5>RStudio</h5>
-                    <span class="label leadership"></span>
-                </div>
                 <div class="col-2 top-12">
                     <img src="/img/team/rich_fitzjohn.jpg" />
                     <h5><a href="http://richfitz.github.io/">Rich FitzJohn</a></h5>

--- a/themes/ropensci/layouts/partials/about.html
+++ b/themes/ropensci/layouts/partials/about.html
@@ -10,24 +10,7 @@
                     <p>Our core team includes staff and postdoctoral fellows. Our leadership and editorial board members are volunteers.</p>
                 </div>
             </div>
-{{ $team := $.Data.team.team }}
-{{ $lenteam := (len $team) }}
-{{ $columns := 4.0 }}
-{{ $rows := div $lenteam $columns }}
-{{ $rows := math.Ceil $rows }}
-{{ range (seq 1 $rows) }}
-  {{ $y := (add (mul (sub . 1)  4) 1)}}
-  <div class="row center">
-  {{ range (seq 1 $columns) }}
-    {{ $i := ( add . $y ) }}
-    {{ $i := (sub $i 2)}}
-    {{ if (le $i (sub $lenteam 1)) }}
-      {{ $teammember := (index $team $i) }}
-      {{ partial "team.html" $teammember }}
-    {{ end }}
-  {{ end }}
-  </div>
-{{ end }}
+{{ partial "team.html" (dict "team" $.Data.team.team)  }}
 </div>
     </section>
     <!-- /team -->
@@ -44,23 +27,7 @@
 {{ end }}
 </div>
 </div>
-
-{{ $columns := 4.0 }}
-{{ $rows := div $lenteam $columns }}
-{{ $rows := math.Ceil $rows }}
-{{ range (seq 1 $rows) }}
-  {{ $y := (add (mul (sub . 1)  4) 1)}}
-  <div class="row center">
-  {{ range (seq 1 $columns) }}
-    {{ $i := ( add . $y ) }}
-    {{ $i := (sub $i 2)}}
-    {{ if (le $i (sub $lenteam 1)) }}
-      {{ $teammember := (index $team $i) }}
-      {{ partial "team.html" $teammember }}
-    {{ end }}
-  {{ end }}
-  </div>
-{{ end }}
+{{ partial "team.html" (dict "team" $.Data.team.alumni)  }}
 </div>
     </section>
     <section id="team" class="team">

--- a/themes/ropensci/layouts/partials/about.html
+++ b/themes/ropensci/layouts/partials/about.html
@@ -28,8 +28,41 @@
   {{ end }}
   </div>
 {{ end }}
+</div>
     </section>
     <!-- /team -->
+<section id="team" class="team">
+        <div class="container">
+{{ $team := $.Data.team.alumni }}
+{{ $lenteam := (len $team) }}
+<div class="row center">
+ <div class="col-10 top-12">
+{{ if ( eq $lenteam 1)}}
+ <h2>Meet our Alumnus</h2>
+{{ else }}
+ <h2>Meet our Alumni</h2>
+{{ end }}
+</div>
+</div>
+
+{{ $columns := 4.0 }}
+{{ $rows := div $lenteam $columns }}
+{{ $rows := math.Ceil $rows }}
+{{ range (seq 1 $rows) }}
+  {{ $y := (add (mul (sub . 1)  4) 1)}}
+  <div class="row center">
+  {{ range (seq 1 $columns) }}
+    {{ $i := ( add . $y ) }}
+    {{ $i := (sub $i 2)}}
+    {{ if (le $i (sub $lenteam 1)) }}
+      {{ $teammember := (index $team $i) }}
+      {{ partial "team.html" $teammember }}
+    {{ end }}
+  {{ end }}
+  </div>
+{{ end }}
+</div>
+    </section>
     <section id="team" class="team">
         <div class="container">
             <div class="row center">

--- a/themes/ropensci/layouts/partials/about.html
+++ b/themes/ropensci/layouts/partials/about.html
@@ -1,13 +1,4 @@
-                <div class="row">
-                    <div class="col-8 col-offset-2 top-0 end bottom-20">
-                        <!-- <p>— Karthik Ram, Project Lead</p> -->
-                    </div>
-                </div>
-            </div>
-        </article>
-
-    </section>
-    <section id="team" class="team">
+<section id="team" class="team">
         <div class="container">
             <div class="row center">
                 <div class="col-10 top-12">
@@ -37,32 +28,6 @@
   {{ end }}
   </div>
 {{ end }}
-            <div class="row center">
-                <div class="col-2 top-12">
-                    <img src="/img/team/jj_allaire.png" />
-                    <h5><a href="https://github.com/jjallaire">JJ Allaire</a></h5>
-                     <h5>RStudio</h5>
-                    <span class="label advisor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/mackenzie_smith.jpg" />
-                    <h5><a href="https://www.library.ucdavis.edu/about/university-librarian/">Mackenzie Smith</a></h5>
-                    <h5>University of California, Davis</h5>
-                    <span class="label advisor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/matt_jones.png" />
-                    <h5><a href="http://matt.magisa.org/">Matt Jones</a></h5>
-                     <h5>NCEAS</h5>
-                    <span class="label advisor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/nico_cellinese.jpg" />
-                    <h5><a href="https://www.floridamuseum.ufl.edu/museum-voices/nico-cellinese/">Nico Cellinese</a></h5>
-                    <h5>University of Florida</h5>
-                    <span class="label advisor"></span>
-                </div>
-            </div>
     </section>
     <!-- /team -->
     <section id="team" class="team">

--- a/themes/ropensci/layouts/partials/about.html
+++ b/themes/ropensci/layouts/partials/about.html
@@ -37,53 +37,6 @@
   {{ end }}
   </div>
 {{ end }}
-
-            <div class="row center">
-                <div class="col-2 top-12">
-                    <img src="/img/team/rich_fitzjohn.jpg" />
-                    <h5><a href="http://richfitz.github.io/">Rich FitzJohn</a></h5>
-                    <h5>Imperial College London</h5>
-                    <span class="label leadership"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/noam_ross.png" />
-                    <h5><a href="http://www.ecohealthalliance.org/personnel/dr-noam-ross">Noam Ross</a></h5>
-                    <h5>EcoHealth Alliance</h5>
-                    <span class="label editor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/anna-krystalli.jpg" />
-                    <h5><a href="http://annakrystalli.me/">Anna Krystalli</a></h5>
-                    <h5>University of Sheffield</h5>
-                    <span class="label editor"></span>
-                </div>
-        	</div>
-            <div class="row center">
-                <div class="col-2 top-12">
-                    <img src="/img/team/lincoln-mullen.jpg" />
-                    <h5><a href="https://lincolnmullen.com/">Lincoln Mullen</a></h5>
-                    <h5>George Mason University</h5>
-                    <span class="label editor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/brooke-anderson.jpg" width = "133"/>
-                    <h5><a href="http://csu-cvmbs.colostate.edu/academics/erhs/Pages/brooke-anderson.aspx">Brooke Anderson</a></h5>
-                    <h5>Colorado State University</h5>
-                    <span class="label editor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/melina-vidoni.jpg" width = "133"/>
-                    <h5><a href="https://melvidoni.rbind.io/">Melina Vidoni</a></h5>
-                    <h5>RMIT University</h5>
-                    <span class="label editor"></span>
-                </div>
-                <div class="col-2 top-12">
-                    <img src="/img/team/hadley-wickham.jpg" />
-                    <h5><a href="http://hadley.nz/">Hadley Wickham</a></h5>
-                     <h5>RStudio</h5>
-                    <span class="label advisor"></span>
-                </div>
-        	</div>
             <div class="row center">
                 <div class="col-2 top-12">
                     <img src="/img/team/jj_allaire.png" />

--- a/themes/ropensci/layouts/partials/about.html
+++ b/themes/ropensci/layouts/partials/about.html
@@ -8,6 +8,28 @@
 
     </section>
     <section id="team" class="team">
+      <div class="container">
+        {{ $team := $.Data.team.team }}
+        {{ $lenteam := 1 }}
+{{ $columns := 4 }}
+{{ $rows := div $lenteam $columns }}
+{{ $rows := math.Ceil $rows }}
+
+{{ range (seq 1 $rows) }}
+{{ $y := . }}
+            <div class="row center">
+{{ range (seq 1 $columns) }}
+{{ $i := ( add . $y ) }}
+                <div class="col-2 top-12">
+                  {{ $teammember := (index $team (sub $i 1)) }}
+   {{ partial "team.html" $teammember }}
+   </div>
+   {{ end }}
+</div>
+{{ end }}
+</div>
+</section>
+    <section id="team" class="team">
         <div class="container">
             <div class="row center">
                 <div class="col-10 top-12">

--- a/themes/ropensci/layouts/partials/team.html
+++ b/themes/ropensci/layouts/partials/team.html
@@ -1,5 +1,5 @@
 <div class="col-2 top-12">
-  <img src="{{ .image }}" />
+  <img src="{{ .image }}"  width = "133"/>
   <h5>{{ if isset . "url"}}
   <a href="{{ .url }}">{{ .name }}</a>
   {{ else }}

--- a/themes/ropensci/layouts/partials/team.html
+++ b/themes/ropensci/layouts/partials/team.html
@@ -1,6 +1,15 @@
 <div class="col-2 top-12">
   <img src="{{ .image }}" />
-  <h5><a href="{{ .url }}">{{ .name }}</a></h5>
+  <h5>{{ if isset . "url"}}
+  <a href="{{ .url }}">{{ .name }}</a>
+  {{ else }}
+  {{ .name }}
+  {{ end }}
+  </h5>
+  {{ if isset . "affiliation"}}
+  <h5>{{ .affiliation}}</h5>
+  {{ end }}
+  </h5>
   {{ range .roles }}
     <span class="label {{ . }}"></span>
   {{ end }}

--- a/themes/ropensci/layouts/partials/team.html
+++ b/themes/ropensci/layouts/partials/team.html
@@ -1,16 +1,18 @@
-<div class="col-2 top-12">
-  <img src="{{ .image }}"  width = "133"/>
-  <h5>{{ if isset . "url"}}
-    <a href="{{ .url }}">{{ .name }}</a>
-  {{ else }}
-    {{ .name }}
+{{ $columns := 4.0 }}
+{{ $team := .team }}
+{{ $lenteam := (len $team) }}
+{{ $rows := div $lenteam $columns }}
+{{ $rows := math.Ceil $rows }}
+{{ range (seq 1 $rows) }}
+{{ $y := (add (mul (sub . 1)  4) 1)}}
+  <div class="row center">
+  {{ range (seq 1 $columns) }}
+    {{ $i := ( add . $y ) }}
+    {{ $i := (sub $i 2)}}
+    {{ if (le $i (sub $lenteam 1)) }}
+      {{ $teammember := (index $team $i) }}
+      {{ partial "teammember.html" $teammember }}
+    {{ end }}
   {{ end }}
-  </h5>
-  {{ if isset . "affiliation"}}
-    <h5>{{ .affiliation}}</h5>
-  {{ end }}
-  </h5>
-  {{ range .roles }}
-    <span class="label {{ . }}"></span>
-  {{ end }}
-</div>
+  </div>
+{{ end }}

--- a/themes/ropensci/layouts/partials/team.html
+++ b/themes/ropensci/layouts/partials/team.html
@@ -1,13 +1,13 @@
 <div class="col-2 top-12">
   <img src="{{ .image }}"  width = "133"/>
   <h5>{{ if isset . "url"}}
-  <a href="{{ .url }}">{{ .name }}</a>
+    <a href="{{ .url }}">{{ .name }}</a>
   {{ else }}
-  {{ .name }}
+    {{ .name }}
   {{ end }}
   </h5>
   {{ if isset . "affiliation"}}
-  <h5>{{ .affiliation}}</h5>
+    <h5>{{ .affiliation}}</h5>
   {{ end }}
   </h5>
   {{ range .roles }}

--- a/themes/ropensci/layouts/partials/team.html
+++ b/themes/ropensci/layouts/partials/team.html
@@ -1,0 +1,7 @@
+<div class="col-2 top-12">
+  <img src="{{ .image }}" />
+  <h5><a href="{{ .url }}">{{ .name }}</a></h5>
+  {{ range .roles }}
+    <span class="label {{ . }}"></span>
+  {{ end }}
+</div>

--- a/themes/ropensci/layouts/partials/teammember.html
+++ b/themes/ropensci/layouts/partials/teammember.html
@@ -1,0 +1,15 @@
+<div class="col-2 top-12">
+  <img src="{{ .image }}"  width = "133"/>
+  <h5>{{ if isset . "url"}}
+    <a href="{{ .url }}">{{ .name }}</a>
+  {{ else }}
+    {{ .name }}
+  {{ end }}
+  </h5>
+  {{ if isset . "affiliation"}}
+    <h5>{{ .affiliation}}</h5>
+  {{ end }}
+  {{ range .roles }}
+    <span class="label {{ . }}"></span>
+  {{ end }}
+</div>


### PR DESCRIPTION
This should make further additions/deletions of people easier: one won't need to shift columns and rows any more, the template takes care of the formatting. People are listed in the same order in the JSON and in the resulting page.

This was also the opportunity for me to get a bit of experience with Hugo data templates that I'll need to improve authors pages with data about their package contributions.