### PR TITLE
change text in commcalls partials

### DIFF
--- a/themes/ropensci/layouts/commcalls/list.html
+++ b/themes/ropensci/layouts/commcalls/list.html
@@ -72,7 +72,7 @@
                     {{end}}
 
                             <div class="top-2"><p><details>
-  <summary><b>☎️ Join the call via Zoom</b> (link only active during scheduled time):</summary> {{ .Params.deets |markdownify }}</details> </p></div>
+  <summary><b>☎️ Join the call via Zoom</b> (click here for details):</summary> {{ .Params.deets |markdownify }}</details> </p></div>
                    </div>
 
 

--- a/themes/ropensci/layouts/commcalls/single.html
+++ b/themes/ropensci/layouts/commcalls/single.html
@@ -40,7 +40,7 @@
 
                             <p>
                                 <details>
-                                    <summary><b>☎️ Join the call via Zoom</b> (link only active during scheduled time):</summary> {{ .Params.deets |markdownify }}</details>
+                                    <summary><b>☎️ Join the call via Zoom</b> (click here for details):</summary> {{ .Params.deets |markdownify }}</details>
                             </p>
                         </div>
 


### PR DESCRIPTION
To address users feedback, trying to make easier to find Zoom details by saying "click here for details" in `themes/ropensci/layouts/commcalls/list.html` and `themes/ropensci/layouts/commcalls/single.html`

Not ideal, but ok till site update