### PR TITLE
Rm extra spaces on events attendees list display

### DIFF
--- a/themes/ropensci/layouts/partials/authorssimpler.html
+++ b/themes/ropensci/layouts/partials/authorssimpler.html
@@ -1,10 +1,7 @@
 {{$pages := .Site.Pages.ByPublishDate.Reverse}}
 {{ range $i, $e := .authors }}
-{{ if $i }}, 
-  {{ end }}
+{{ if $i }}-{{ end }}
                             
-  {{ range first 1 (where $pages ".Params.name" $e) }}
-                            &nbsp;
-                            <a href="{{ .RelPermalink }}">{{ .Params.name }}</a>
+  {{ range first 1 (where $pages ".Params.name" $e) }}<a href="{{ .RelPermalink }}">{{ .Params.name }}</a>
   {{ end }}
 {{end}}


### PR DESCRIPTION
cf #488 

Preview https://deploy-preview-549--ropensci.netlify.com/events/

I furthermore replaced commas with hyphens because 1) I couldn't figure out how to remove the small space before commas 2) I think it actually looks better?

Locally I changed the date of the useR! 2019 event to see how it looks with more than 2 attendees:

![image](https://user-images.githubusercontent.com/8360597/68281039-16b09180-0077-11ea-932d-313ad3762665.png)
