### PR TITLE
Random order for packages page

### DIFF
--- a/themes/ropensci/static/js/tableinit.js
+++ b/themes/ropensci/static/js/tableinit.js
@@ -9,6 +9,7 @@ $(document).ready( function () {
             "url": "https://ropensci.github.io/roregistry/registry.json",
             "dataSrc": "packages"
         },
+        "order": [[ 3, "asc" ]],
         "columns": [
           {
                 "data" : function(row, type, set, meta){
@@ -27,6 +28,14 @@ $(document).ready( function () {
                 data: 'status',
                 visible: false,
                 title: "status"
+            },
+            {
+                data: function ( row, type, val, meta ) {
+                   return Math.floor(Math.random() * 100000)
+                    
+                },
+                visible: false,
+                title: "rand"
             },
             {
                 "data": function(row, type, set, meta){


### PR DESCRIPTION
cf #537: each time you reload https://deploy-preview-588--ropensci.netlify.com/packages/ you get a different order.

I am not sure it's JS best practice, but... it works and I get no error in the console.

By the way is it intuitive to click on column names to sort by the column? E.g. if you click on Name it sorts by name but I forget that all the time.