### PR TITLE
fix preview of twitterImg

### DIFF
--- a/themes/ropensci/layouts/partials/head.html
+++ b/themes/ropensci/layouts/partials/head.html
@@ -55,10 +55,10 @@
 
   {{ if .Params.twitterImg }}
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="{{.Site.BaseURL }}{{ .Params.twitterImg }}" >
+    <meta name="twitter:image" content="{{ .Params.twitterImg | absURL }}" >
   {{ else }}
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:image" content="{{.Site.BaseURL }}android-chrome-512x512.png" >
+    <meta name="twitter:image" content="{{ "android-chrome-512x512.png"  | absURL }}" >
   {{ end }}
 
 {{ end }}


### PR DESCRIPTION
 thx to https://discourse.gohugo.io/t/deploy-previews-on-netlify-are-built-with-the-wrong-baseurl-not-using-deploy-prime-url/13549/2