### PR TITLE
Remove "technote" from authors

### DIFF
--- a/content/technotes/2018-01-25-nodbi.Rmd
+++ b/content/technotes/2018-01-25-nodbi.Rmd
@@ -3,7 +3,7 @@ slug: nodbi
 title: 'nodbi: the NoSQL Database Connector'
 date: '2018-01-25'
 author:
-  - name: Scott Chamberlain
+  - Scott Chamberlain
 topicid: ~
 tags:
   - R

--- a/content/technotes/2018-02-20-webmockr-intro.Rmd
+++ b/content/technotes/2018-02-20-webmockr-intro.Rmd
@@ -3,8 +3,7 @@ slug: "webmockr-intro"
 title: "webmockr: mock HTTP requests"
 date: 2018-02-20
 author:
-  - name: Scott Chamberlain
-  - technotes
+  - Scott Chamberlain
 topicid: 1073
 tags:
 - R

--- a/content/technotes/2018-05-23-taxize-seven-years.Rmd
+++ b/content/technotes/2018-05-23-taxize-seven-years.Rmd
@@ -3,8 +3,7 @@ slug: "taxize-seven-years"
 title: "taxize: seven years of taxonomy in R"
 date: 2018-05-23
 author:
-  - name: Scott Chamberlain
-  - technotes
+  - Scott Chamberlain
 topicid: 1181
 tags:
 - R

--- a/content/technotes/2018-08-22-rgbif-seven-years.Rmd
+++ b/content/technotes/2018-08-22-rgbif-seven-years.Rmd
@@ -3,8 +3,7 @@ slug: "rgbif-seven-years"
 title: "rgbif: seven years of GBIF in R"
 date: 2018-08-22
 author:
-  - name: Scott Chamberlain
-  - technotes
+  - Scott Chamberlain
 topicid: 1307
 tags:
 - R

--- a/content/technotes/2018-10-16-pubchunks.Rmd
+++ b/content/technotes/2018-10-16-pubchunks.Rmd
@@ -3,8 +3,7 @@ slug: "pubchunks"
 title: "pubchunks: extract parts of scholarly XML articles"
 date: 2018-10-16
 author:
-  - name: Scott Chamberlain
-  - technotes
+  - Scott Chamberlain
 topicid: 1415
 tags:
 - R

--- a/content/technotes/2018-12-04-rnoaa-update.Rmd
+++ b/content/technotes/2018-12-04-rnoaa-update.Rmd
@@ -3,8 +3,7 @@ slug: "rnoaa-update"
 title: "rnoaa: new data sources and NCDC units"
 date: 2018-12-04
 author:
-  - name: Scott Chamberlain
-  - technotes
+  - Scott Chamberlain
 topicid: 1497
 tags:
 - R

--- a/content/technotes/2019-02-27-handlr-release.Rmd
+++ b/content/technotes/2019-02-27-handlr-release.Rmd
@@ -4,7 +4,6 @@ title: "handlr: convert among citation formats"
 date: 2019-02-27
 author:
   - Scott Chamberlain
-  - technotes
 topicid: 1598
 tags:
 - R

--- a/content/technotes/2019-02-27-handlr-release.md
+++ b/content/technotes/2019-02-27-handlr-release.md
@@ -4,7 +4,6 @@ title: "handlr: convert among citation formats"
 date: 2019-02-27
 author:
   - Scott Chamberlain
-  - technotes
 topicid: 1598
 tags:
 - R

--- a/content/technotes/2019-04-24-conditionz.Rmd
+++ b/content/technotes/2019-04-24-conditionz.Rmd
@@ -4,7 +4,6 @@ title: "conditionz: control how many times conditions are thrown"
 date: 2019-04-24
 author:
   - Scott Chamberlain
-  - technotes
 topicid: 1680
 tags:
 - R

--- a/content/technotes/2019-04-24-conditionz.md
+++ b/content/technotes/2019-04-24-conditionz.md
@@ -4,7 +4,6 @@ title: "conditionz: control how many times conditions are thrown"
 date: 2019-04-24
 author:
   - Scott Chamberlain
-  - technotes
 topicid: 1680
 tags:
 - R

--- a/content/technotes/2019-09-17-citecorp.Rmd
+++ b/content/technotes/2019-09-17-citecorp.Rmd
@@ -4,7 +4,6 @@ title: "citecorp: working with open citations"
 date: 2019-09-17
 author:
   - Scott Chamberlain
-  - technotes
 topicid: 1832
 tags:
 - R

--- a/content/technotes/2019-09-17-citecorp.md
+++ b/content/technotes/2019-09-17-citecorp.md
@@ -4,7 +4,6 @@ title: "citecorp: working with open citations"
 date: 2019-09-17
 author:
   - Scott Chamberlain
-  - technotes
 topicid: 1832
 tags:
 - R

--- a/content/technotes/2019-10-09-cran-checks-api-update.md
+++ b/content/technotes/2019-10-09-cran-checks-api-update.md
@@ -4,7 +4,6 @@ title: "cran checks API: an update"
 date: 2019-10-09
 author:
   - Scott Chamberlain
-  - technotes
 topicid: 1851
 tags:
 - R

--- a/content/technotes/2019-11-14-workloopR-release.Rmd
+++ b/content/technotes/2019-11-14-workloopR-release.Rmd
@@ -5,7 +5,6 @@ package_version: 1.1.2
 author:
   - Vikram B. Baliga
 date: 2019-11-14
-  - technotes
 topicid:
 tags:
 - Software Peer Review

--- a/content/technotes/2019-11-14-workloopR-release.md
+++ b/content/technotes/2019-11-14-workloopR-release.md
@@ -5,7 +5,6 @@ package_version: 1.1.2
 author:
   - Vikram B. Baliga
 date: 2019-11-14
-  - technotes
 topicid: 1879
 tags:
 - Software Peer Review

--- a/content/technotes/2019-12-11-http-testing.Rmd
+++ b/content/technotes/2019-12-11-http-testing.Rmd
@@ -4,7 +4,6 @@ title: "HTTP testing in R: overview of tools and new features"
 date: 2019-12-11
 author:
   - Scott Chamberlain
-  - technotes
 topicid: 1900
 tags:
 - R

--- a/content/technotes/2019-12-11-http-testing.md
+++ b/content/technotes/2019-12-11-http-testing.md
@@ -4,7 +4,6 @@ title: "HTTP testing in R: overview of tools and new features"
 date: 2019-12-11
 author:
   - Scott Chamberlain
-  - technotes
 topicid: 1900
 tags:
 - R

--- a/content/technotes/2020-02-25-opentripplanner.Rmd
+++ b/content/technotes/2020-02-25-opentripplanner.Rmd
@@ -5,7 +5,6 @@ package_version: 0.2.0
 date: 2020-02-25
 author:
   - Malcolm Morgan
-  - technotes
 topicid: 1966
 tags:
 - R

--- a/content/technotes/2020-02-25-opentripplanner.md
+++ b/content/technotes/2020-02-25-opentripplanner.md
@@ -5,7 +5,6 @@ package_version: 0.2.0
 date: 2020-02-25
 author:
   - Malcolm Morgan
-  - technotes
 topicid: 1966
 tags:
 - R


### PR DESCRIPTION
In the (list of technotes)[https://ropensci.org/technotes/] it looks like opentripplanner has "technote" as an author. I think this is in error?