### PR TITLE
Fix mixed content warnings

### DIFF
--- a/content/blog/2013-07-29-esa-2013.md
+++ b/content/blog/2013-07-29-esa-2013.md
@@ -59,4 +59,4 @@ We are also excited to annouce the first ever rOpenSci happy hour thanks to gene
 
 Location: <a href="https://www.britspub.com/"></a>Brit's Pub</a>, 3rd floor Verandah bar. 6:30 pm. Generously sponsored by [GitHub](https://github.com/).
 
-<iframe width='800' height='300' frameBorder='0' src='http://a.tiles.mapbox.com/v3/karthikram.map-058ycvw2.html#18/44.97281925628907/-93.27609166502953'></iframe>
+<iframe width='800' height='300' frameBorder='0' src='https://a.tiles.mapbox.com/v3/karthikram.map-058ycvw2.html#18/44.97281925628907/-93.27609166502953'></iframe>

--- a/content/blog/2013-11-04-data-to-cartodb.md
+++ b/content/blog/2013-11-04-data-to-cartodb.md
@@ -103,7 +103,7 @@ lapply(rows, function(x) cartodb.row.insert(name = "pumamap", columns = list("na
 
 After the upload is finished, I had to make sure the table was georeferenced, and played with settings to suit my style. And then I made a visualization from the `pumamap` dataset and made it public. And that's it!  You can [find the map](https://cdb.io/1fbvgCG), and it can be embedded:
 
-<iframe width='100%' height='400' frameborder='0' src='http://recology.cartodb.com/viz/76a5598e-444b-11e3-8a8c-5404a6a69006/embed_map?title=false&description=false&search=false&shareable=false&cartodb_logo=true&layer_selector=false&legends=false&scrollwheel=true&sublayer_options=1&sql=&zoom=3&center_lat=37.61423141542417&center_lon=-100.72265625'></iframe>
+<iframe width='100%' height='400' frameborder='0' src='https://recology.cartodb.com/viz/76a5598e-444b-11e3-8a8c-5404a6a69006/embed_map?title=false&description=false&search=false&shareable=false&cartodb_logo=true&layer_selector=false&legends=false&scrollwheel=true&sublayer_options=1&sql=&zoom=3&center_lat=37.61423141542417&center_lon=-100.72265625'></iframe>
 
 
 And we can examine a row from the table in our CartoDB account with a single line of code

--- a/content/blog/2017-08-15-magick-10.md
+++ b/content/blog/2017-08-15-magick-10.md
@@ -32,11 +32,11 @@ For example [Bob Rudis](https://twitter.com/hrbrmstr/status/758304420224466944) 
 
 R-ladies [Lucy D'Agostino McGowan](https://www.lucymcgowan.com/) and [Maëlle Salmon](https://masalmon.eu/) demonstrate how to make a beautiful collage:
 
-[![collage](http://livefreeordichotomize.com/images/we-r-ladies.jpeg)](https://livefreeordichotomize.com/2017/07/18/the-making-of-we-r-ladies/)
+[![collage](https://livefreeordichotomize.com/images/we-r-ladies.jpeg)](https://livefreeordichotomize.com/2017/07/18/the-making-of-we-r-ladies/)
 
 And [Daniel P. Hadley](https://twitter.com/danielphadley/status/884845188979359744) lets Vincent Vega explains Cars:
 
-[![travolta](http://danielphadley.com/images/Cars_Travolta.gif)](https://danielphadley.com/ggplot-Logo/)
+[![travolta](https://danielphadley.com/images/Cars_Travolta.gif)](https://danielphadley.com/ggplot-Logo/)
 
 Now, 1 year later, the 1.0 release marks an important milestone: the addition of a new native graphics device (which serves as a hybrid between a magick image object and an R plot) bridges the gap between graphics and image processing in R.
 

--- a/content/blog/2017-09-11-software-review-update.md
+++ b/content/blog/2017-09-11-software-review-update.md
@@ -102,8 +102,8 @@ As submissions increase, the entire process benefits more from automation. Right
 - Reviewer template and guide: We now have a [reviewer template][revtemp] - making reviews more standardized, and helping reviewers know what to look for. In addition, we have an updated reviewer guide that gives high level guidance, as well as specific things to look for, tools to use, and examples of good reviews. In addition, the guide gives guidance on how to submit reviews.
 - Badges: We now have badges for rOpenSci review. The badges show whether a package is under review or has been approved. Packages that are undergoing review or have been approved can put this badge in their README.
 
-    [![](http://badges.ropensci.org/86_status.svg)](https://github.com/ropensci/software-review/issues/86)
-    [![](http://badges.ropensci.org/116_status.svg)](https://github.com/ropensci/software-review/issues/116)
+    [![](https://badges.ropensci.org/86_status.svg)](https://github.com/ropensci/software-review/issues/86)
+    [![](https://badges.ropensci.org/116_status.svg)](https://github.com/ropensci/software-review/issues/116)
 
 
 ---

--- a/content/code-of-conduct.md
+++ b/content/code-of-conduct.md
@@ -62,7 +62,7 @@ The rOpenSci Code of Conduct has been influenced by and adapted from many source
 <p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
   <a rel="license"
      href="https://creativecommons.org/publicdomain/zero/1.0/">
-    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none; width: 88px;" alt="CC0" />
+    <img src="https://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none; width: 88px;" alt="CC0" />
   </a>
   <br />
   To the extent possible under law,

--- a/content/technotes/2019-09-27-imaging-stack.md
+++ b/content/technotes/2019-09-27-imaging-stack.md
@@ -38,7 +38,7 @@ dev.off()
 image_shadow(img, geometry = "100x20+30+30")
 ```
 
-![ggplot2-shadow](http://jeroen.github.io/images/ggplot2-shadow.png)
+![ggplot2-shadow](https://jeroen.github.io/images/ggplot2-shadow.png)
 
 So fancy! Another cool example from Twitter:
 

--- a/content/tutorials/rorcid_tutorial.Rmd
+++ b/content/tutorials/rorcid_tutorial.Rmd
@@ -63,7 +63,7 @@ The `browse()` function lets you browser to a profile easily with a single funct
 browse(as.orcid("0000-0002-1642-628X"))
 ```
 
-![profile](http://f.cl.ly/items/3d1o0k1X3R1U110C0u1u/Screen%20Shot%202015-02-10%20at%207.21.57%20PM.png)
+![profile](https://f.cl.ly/items/3d1o0k1X3R1U110C0u1u/Screen%20Shot%202015-02-10%20at%207.21.57%20PM.png)
 
 ### Get works
 

--- a/content/tutorials/rorcid_tutorial.md
+++ b/content/tutorials/rorcid_tutorial.md
@@ -89,7 +89,7 @@ The `browse()` function lets you browser to a profile easily with a single funct
 browse(as.orcid("0000-0002-1642-628X"))
 ```
 
-![profile](http://f.cl.ly/items/3d1o0k1X3R1U110C0u1u/Screen%20Shot%202015-02-10%20at%207.21.57%20PM.png)
+![profile](https://f.cl.ly/items/3d1o0k1X3R1U110C0u1u/Screen%20Shot%202015-02-10%20at%207.21.57%20PM.png)
 
 ### Get works
 


### PR DESCRIPTION
I noticed these warnings while netlify was preparing the preview of a blog post. Mixed content warnings signal that some resources (images, script, iframes...) are loaded over HTTP while the main page is loaded over HTTPS (more info: https://support.mozilla.org/en-US/kb/mixed-content-blocking-firefox).

I found two cases of mixed content:

- passive mixed content with images. This is not a big issue from a security point of view but it still creates a warning in most browsers (![warning](https://user-media-prod-cdn.itsre-sumo.mozilla.net/uploads/gallery/images/2015-10-21-18-54-26-fe01d6.png)) that may be worrying to some users (or teach them to ignore this kind of warning which may be even worse).

- active mixed content with iframes. This is more problematic since active mixed content could pose serious security issues and is therefore blocked by most browsers. This means the content in the iframe won't be displayed.